### PR TITLE
Correct bug with newer torchvision versions

### DIFF
--- a/state-change-object-detection-baselines/DETR/util/misc.py
+++ b/state-change-object-detection-baselines/DETR/util/misc.py
@@ -18,7 +18,7 @@ from torch import Tensor
 
 # needed due to empty tensor bug in pytorch and torchvision 0.5
 import torchvision
-if float(torchvision.__version__[:3]) < 0.7:
+if int(torchvision.__version__.split('.')[1]) < 7:
     from torchvision.ops import _new_empty_tensor
     from torchvision.ops.misc import _output_size
 
@@ -454,7 +454,7 @@ def interpolate(input, size=None, scale_factor=None, mode="nearest", align_corne
     This will eventually be supported natively by PyTorch, and this
     class can go away.
     """
-    if float(torchvision.__version__[:3]) < 0.7:
+    if int(torchvision.__version__.split('.')[1]) < 7:
         if input.numel() > 0:
             return torch.nn.functional.interpolate(
                 input, size, scale_factor, mode, align_corners


### PR DESCRIPTION
The current check fails for torchvision versions >= 0.10. This commit corrects the parsing of the version number.